### PR TITLE
Add support for cake.cs file-based Cake.Sdk builds

### DIFF
--- a/src/Make/BuildContext.cs
+++ b/src/Make/BuildContext.cs
@@ -5,17 +5,20 @@ namespace Make;
 public sealed class BuildContext
 {
     public DirectoryPath Root { get; }
+    public Spectre.IO.Path[] Candidates { get; }
     public IRemainingArguments RemainingArguments { get; }
     public string? Target { get; }
     public bool Trace { get; }
 
     public BuildContext(
         DirectoryPath root,
+        Spectre.IO.Path[] candidates,
         string? target,
         bool trace,
         IRemainingArguments remainingArguments)
     {
         Root = root;
+        Candidates = candidates;
         Target = target;
         Trace = trace;
         RemainingArguments = remainingArguments ?? throw new ArgumentNullException(nameof(remainingArguments));

--- a/src/Make/BuildRunnerSelector.cs
+++ b/src/Make/BuildRunnerSelector.cs
@@ -1,4 +1,6 @@
+using Spectre.Console;
 using Spectre.IO;
+using Path = Spectre.IO.Path;
 
 namespace Make;
 
@@ -34,7 +36,7 @@ public sealed class BuildRunnerSelector
         }
     }
 
-    public (DirectoryPath Root, IBuildRunner Runner)? Find(MakeSettings settings)
+    public (DirectoryPath Root, IBuildRunner Runner, Path[] Candidates)? Find(MakeSettings settings)
     {
         var comparer = new PathComparer(caseSensitive: false);
 
@@ -66,12 +68,14 @@ public sealed class BuildRunnerSelector
                             Comparer = comparer,
                         });
 
-                    if (candidates.Any())
+                    if (candidates?.ToArray() is Path[] { Length: > 0 } foundCandidates)
                     {
                         if (settings.Trace)
                         {
                             _console.MarkupLine(
                                 $"[gray]Found root[/] {current.FullPath} [gray]using glob[/] {glob}");
+                            _console.MarkupLine(
+                                $"[gray]Found candidates:[/] {string.Join<Path>(',', foundCandidates)}");
                         }
 
                         if (runner.CanRun(settings, current))
@@ -81,7 +85,7 @@ public sealed class BuildRunnerSelector
                                 _console.MarkupLine($"[gray]Using runner[/] {runner.Name}");
                             }
 
-                            return (current, runner);
+                            return (current, runner, foundCandidates);
                         }
                     }
                 }

--- a/src/Make/Commands/DefaultCommand.cs
+++ b/src/Make/Commands/DefaultCommand.cs
@@ -58,6 +58,7 @@ public sealed class DefaultCommand : AsyncCommand<DefaultCommand.Settings>
 
         var buildContext = new BuildContext(
             result.Value.Root,
+            result.Value.Candidates,
             settings.Target,
             settings.Trace,
             context.Remaining);

--- a/src/Make/Runners/CakeFileRunner.cs
+++ b/src/Make/Runners/CakeFileRunner.cs
@@ -21,7 +21,7 @@ public sealed class CakeFileRunner : IBuildRunner
 
     public IEnumerable<string> GetGlobs(MakeSettings settings)
     {
-        return ["./build.cs"];
+        return ["./build.cs", "./cake.cs"];
     }
 
     public bool CanRun(MakeSettings settings, DirectoryPath path)
@@ -45,7 +45,7 @@ public sealed class CakeFileRunner : IBuildRunner
     {
         var args = new List<string>
         {
-            "build.cs",
+            context.Candidates.FirstOrDefault()?.Segments.LastOrDefault() ?? "build.cs",
         };
 
         if (context.Target != null)


### PR DESCRIPTION
Extend CakeFileRunner to support both `build.cs` and `cake.cs` files. 

The runner now searches for both file patterns and uses the first candidate found when executing the build.

Changes:
- Add Candidates property to BuildContext to track found build files
- Update BuildRunnerSelector to return candidate files along with root
- Add cake.cs to glob patterns in CakeFileRunner
- Use first candidate file instead of hardcoding build.cs
- Add trace logging to display found candidate files