### PR TITLE
Add support for recipe.cake file

### DIFF
--- a/src/Make/Runners/CakeRunner.cs
+++ b/src/Make/Runners/CakeRunner.cs
@@ -21,7 +21,7 @@ public sealed class CakeRunner : IBuildRunner
 
     public IEnumerable<string> GetGlobs(MakeSettings settings)
     {
-        return ["./build.cake"];
+        return ["./build.cake", "recipe.cake"];
     }
 
     public bool CanRun(MakeSettings settings, DirectoryPath path)
@@ -43,7 +43,10 @@ public sealed class CakeRunner : IBuildRunner
 
     private static string GetArgs(BuildContext context)
     {
-        var args = new List<string>();
+        var args = new List<string>
+        {
+            context.Candidates.FirstOrDefault()?.Segments.LastOrDefault() ?? "build.cake",
+        };
 
         if (context.Target != null)
         {


### PR DESCRIPTION
Extend CakeRunner to support both build.cake and
recipe.cake files.
The runner now searches for both file patterns and uses the first candidate found when executing the build.

Changes:
- Add recipe.cake to glob patterns in CakeRunner
- Use first candidate file instead of hardcoding build.cake

This is based on the work that @devlead just submitted to add support for cake.cs files.