### PR TITLE
(maint) Fix glob path for recipe.cake file

### DIFF
--- a/src/Make/Runners/CakeRunner.cs
+++ b/src/Make/Runners/CakeRunner.cs
@@ -21,7 +21,7 @@ public sealed class CakeRunner : IBuildRunner
 
     public IEnumerable<string> GetGlobs(MakeSettings settings)
     {
-        return ["./build.cake", "recipe.cake"];
+        return ["./build.cake", "./recipe.cake"];
     }
 
     public bool CanRun(MakeSettings settings, DirectoryPath path)


### PR DESCRIPTION
When initial support for inclusion of the recipe.cake file was added in this PR:

https://github.com/patriksvensson/dotnet-make/pull/4

The glob pattern was not entered correctly.  It should have included `.\` at the start, similar to how it is done for the `.\build.cake` file.